### PR TITLE
fix: use RedisURI instead of redisUri string for Redis connection

### DIFF
--- a/src/main/java/dev/hytaleone/query/config/NetworkConfig.java
+++ b/src/main/java/dev/hytaleone/query/config/NetworkConfig.java
@@ -3,6 +3,7 @@ package dev.hytaleone.query.config;
 import com.hypixel.hytale.codec.Codec;
 import com.hypixel.hytale.codec.KeyedCodec;
 import com.hypixel.hytale.codec.builder.BuilderCodec;
+import io.lettuce.core.RedisURI;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -283,6 +284,7 @@ public class NetworkConfig {
         /**
          * Build a Redis URI string for Lettuce.
          */
+        @Deprecated
         @Nonnull
         public String toRedisUri() {
             StringBuilder sb = new StringBuilder();
@@ -297,6 +299,26 @@ public class NetworkConfig {
                 sb.append("/").append(database);
             }
             return sb.toString();
+        }
+
+        /**
+         * Build a Redis URI for Lettuce connection.
+         */
+        @Nonnull
+        public RedisURI toRedisURI() {
+            RedisURI.Builder builder = RedisURI.builder()
+                    .withHost(getHost())
+                    .withPort(getPort())
+                    .withDatabase(getDatabase());
+            if (getUsername() != null && !getUsername().isEmpty()) {
+                builder.withAuthentication(getUsername(), getPassword() != null ? getPassword().toCharArray() : new char[0]);
+            } else if (getPassword() != null && !getPassword().isEmpty()) {
+                builder.withPassword(getPassword().toCharArray());
+            }
+            if (isUseTLS()) {
+                builder.withSsl(true);
+            }
+            return builder.build();
         }
     }
 

--- a/src/main/java/dev/hytaleone/query/network/NetworkModule.java
+++ b/src/main/java/dev/hytaleone/query/network/NetworkModule.java
@@ -11,6 +11,7 @@ import dev.hytaleone.query.network.model.ServerState;
 import dev.hytaleone.query.network.store.NetworkStateStore;
 import dev.hytaleone.query.network.store.RedisStateStore;
 import dev.hytaleone.query.protocol.ServerDataProvider;
+import io.lettuce.core.RedisURI;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -235,7 +236,7 @@ public class NetworkModule {
         if (!config.getStore().isRedis()) {
             throw new IllegalStateException("Network mode requires Redis configuration. Set Store.Type to 'redis' and configure Redis connection.");
         }
-        String redisUri = config.getStore().getRedis().toRedisUri();
+        RedisURI redisUri = config.getStore().getRedis().toRedisURI();
         return new RedisStateStore(
                 logger,
                 config.getNetworkId(),

--- a/src/main/java/dev/hytaleone/query/network/store/RedisStateStore.java
+++ b/src/main/java/dev/hytaleone/query/network/store/RedisStateStore.java
@@ -10,14 +10,7 @@ import dev.hytaleone.query.network.model.NetworkEvent;
 import dev.hytaleone.query.network.model.NetworkSnapshot;
 import dev.hytaleone.query.network.model.PlayerInfo;
 import dev.hytaleone.query.network.model.ServerState;
-import io.lettuce.core.ClientOptions;
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.RedisCommandExecutionException;
-import io.lettuce.core.ScriptOutputType;
-import io.lettuce.core.SocketOptions;
-import io.lettuce.core.StreamMessage;
-import io.lettuce.core.TimeoutOptions;
-import io.lettuce.core.XReadArgs;
+import io.lettuce.core.*;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.resource.ClientResources;
@@ -223,6 +216,22 @@ public class RedisStateStore implements NetworkStateStore {
         this.networkId = networkId;
         this.serverId = serverId;
         this.redisUri = redisUri;
+        this.timing = timing;
+        this.subscribe = subscribe;
+        this.cache = new LocalStateCache();
+        this.cache.setServerTimeout(NetworkModule.SERVER_TIMEOUT_MILLIS);
+    }
+
+    public RedisStateStore(@Nonnull HytaleLogger logger,
+                           @Nonnull String networkId,
+                           @Nonnull String serverId,
+                           @Nonnull RedisURI redisUri,
+                           @Nonnull NetworkConfig.TimingConfig timing,
+                           boolean subscribe) {
+        this.logger = logger;
+        this.networkId = networkId;
+        this.serverId = serverId;
+        this.redisUri = redisUri.toURI().toString();
         this.timing = timing;
         this.subscribe = subscribe;
         this.cache = new LocalStateCache();


### PR DESCRIPTION
Use RedisURI builder to generate the expected uri, following Lettuce expectation