### PR TITLE
Fix Java 25 build

### DIFF
--- a/.github/workflows/auto-bump-hytale.yml
+++ b/.github/workflows/auto-bump-hytale.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,7 @@
 
     <properties>
         <revision>2.0.2-SNAPSHOT</revision>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lettuce.version>6.3.2.RELEASE</lettuce.version>
         <hytale.server.version>0.5.6</hytale.server.version>


### PR DESCRIPTION
## Summary
- target Java 25 in Maven because Hytale Server 0.5.6 is compiled for classfile 69
- run GitHub workflows with JDK 25
- update maven-shade-plugin for Java 25 classfile support

## Test
- mvn clean package -B -DskipTests